### PR TITLE
Fix unary syntax in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ frequency_table(Xt,vard)
 
 
 ```python
-unary = [v for v in vard if Xt[v].nunique==1]
+unary = [v for v in vard if Xt[v].nunique()==1]
 unary
 ```
 


### PR DESCRIPTION
### Problem
The `README.md` example for defining `unary` contains a syntax issue:
- It uses `Xt[v].nunique` instead of the correct `Xt[v].nunique()`.

### Solution
This PR corrects the syntax by replacing `Xt[v].nunique` with `Xt[v].nunique()` to properly call the method and retrieve the number of unique values.
